### PR TITLE
Add support for building on Windows with MSVC.

### DIFF
--- a/BUILD.halide_distrib.tpl
+++ b/BUILD.halide_distrib.tpl
@@ -22,9 +22,24 @@ cc_library(
   includes = ["distrib/include"]
 )
 
+# Config setting to catch the case where someone is trying to build
+# on Windows, but forgot to specify --host_cpu=x64_windows_msvc AND
+# --cpu=x64_windows_msvc .
+config_setting(
+    name = "windows_not_using_msvc",
+    values = { "cpu": "x64_windows" }
+)
+
 cc_library(
   name="lib_halide_static",
-  srcs = ["distrib/lib/libHalide.a"],
+  srcs = select({
+    ":windows_not_using_msvc": ["please_set_host_cpu_and_cpu_to_x86_64_windows"],
+    ":config_x86_64_windows": [
+      "distrib/Release/Halide.lib",
+      "distrib/Release/Halide.dll"
+    ],
+    "//conditions:default": ["distrib/lib/libHalide.a"],
+  }),
   hdrs = ["distrib/include/Halide.h"],
   includes = ["distrib/include"],
 )

--- a/halide_configure.bzl
+++ b/halide_configure.bzl
@@ -46,11 +46,22 @@ _HOST_DEFAULTS_K8 = {
   ]
 }
 
-# Windows, FreeBSD, etc: sorry, not supported as compile host (yet).
+# "x64_windows_msvc" -> host is Windows x86-64
+_HOST_DEFAULTS_WIN64 = {
+  "copts": _COPTS_DEFAULT,
+  "linkopts": [],
+  "http_archive_info": [
+    "https://github.com/halide/Halide/releases/download/release_2016_10_25/halide-win-64-trunk-aa5d5514f179bf0ffe1a2dead0c0eb7300b4069a.zip",
+    "17910e65edd9c7a3df74db73b11bc3bca021186f81beab82c245529839e45e98",
+  ]
+}
+
+# FreeBSD, etc: sorry, not supported as compile host (yet).
 _HOST_DEFAULTS = {
     "darwin": _HOST_DEFAULTS_DARWIN,
     "piii": _HOST_DEFAULTS_PIII,
     "k8": _HOST_DEFAULTS_K8,
+    "x64_windows_msvc": _HOST_DEFAULTS_WIN64,
 }
 
 def _get_cpu_value(repository_ctx):
@@ -61,7 +72,7 @@ def _get_cpu_value(repository_ctx):
   if os_name.find("freebsd") != -1:
     return "freebsd"
   if os_name.find("windows") != -1:
-    return "x64_windows"
+    return "x64_windows_msvc"
   # Use uname to figure out whether we are on x86_32 or x86_64
   result = repository_ctx.execute(["uname", "-m"])
   return "piii" if result.stdout.strip() == "i386" else "k8"


### PR DESCRIPTION
Here are changes that get Windows working. I tested these changes by building the example/ directory with the following command-line inside a Msys2 shell.
bazel run --host_cpu=x64_windows_msvc --cpu=x64_windows_msvc :main

This only works with MSVC builds because the Halide release distributions for Windows are only built with MSVC. I'm also not a Bazel expert so please let me know if there is an easier way to do something here.